### PR TITLE
bug fixes

### DIFF
--- a/R/btable.r
+++ b/R/btable.r
@@ -168,17 +168,21 @@ btable<-function(dat,
 			ms<-match(head1,uh)
 			msum<-numeric(0)
 			m<-1
-			for (i in 2:length(head1)) {
-				if (!is.na(head1[i]) & !is.na(head1[i-1]) & head1[i]==head1[i-1]) {
-					m<-m+1
-				} else {
-				msum<-append(msum,m)
-				m<-1
-				}
-				if (i==length(head1)) {
+			if (length(head1)>1) {
+				for (i in 2:length(head1)) {
+					if (!is.na(head1[i]) & !is.na(head1[i-1]) & head1[i]==head1[i-1]) {
+						m<-m+1
+					} else {
 					msum<-append(msum,m)
+					m<-1
+					}
+					if (i==length(head1)) {
+						msum<-append(msum,m)
+					}
 				}
-			}
+			} else {
+				msum<-1
+			}			
 			hft<-numeric(0)
 			for (i in 1:length(msum)) {
 				msi<-msum[i]

--- a/R/btable.r
+++ b/R/btable.r
@@ -109,12 +109,22 @@ btable<-function(dat,
                  comment = FALSE,
                  ...) {
 
-
+	
+	#checks and warnings:
+	
+	if (!is.na(aligntot)) { 
+		if (aggregate) {
+			warning(paste0("The header rows to not respect aligntot if aggregate==TRUE (the default)---",
+				"use aggregate=FALSE to use aligntot for the headers."))
+		}
+	}
+	
 	#load data
 
 	dat<-apply(dat,2,as.character)
 
 	#prepare footers:
+	
 	if (nfoot>0) {
 		subs<-numeric(0)
 

--- a/R/btable.r
+++ b/R/btable.r
@@ -159,6 +159,11 @@ btable<-function(dat,
 	if (nnewline>0) {
 		lw<-dat[,1][nchar(dat[,1])>nnewline]
 		sp<-strsplit(lw," ")
+		if (any(nchar(unlist(sp))>nnewline)) {
+			wlong<-paste(unlist(sp)[nchar(unlist(sp))>nnewline],collapse=", ")
+			warning(paste0("Words ",wlong," in first column are longer than ",nnewline," characters ",
+				"and cannot be split."))
+		}
 		tor<-lapply(sp,function(x) newline(x,nmax=nnewline,indent=indent))
 		dat[,1][nchar(dat[,1])>nnewline]<-unlist(tor)
 		dat<-data.frame(dat)

--- a/R/newline.R
+++ b/R/newline.R
@@ -1,13 +1,21 @@
 #function for pretty separation
 
 newline<-function(x,nmax=35,indent=1) {
+  
   f2<-function(x,nmax=nmax) {
     w21<-paste(x[cumsum(nchar(x)+1)<=nmax],collapse=" ")
     w22<-paste(x[cumsum(nchar(x)+1)>nmax],collapse=" ")
     c(w21,w22)
   }
+  
   w1<-paste(x[cumsum(nchar(x)+1)<=nmax],collapse=" ")
   w2<-paste(x[cumsum(nchar(x)+1)>nmax],collapse=" ")
+  if (w1=="") {
+	nmax<-nchar(strsplit(x," ")[1])+1
+	w1<-paste(x[cumsum(nchar(x)+1)<=nmax],collapse=" ")
+	w2<-paste(x[cumsum(nchar(x)+1)>nmax],collapse=" ")
+  }
+  
   w1c<-w1
   w2c<-w2
   wcoll<-numeric(0)
@@ -26,20 +34,23 @@ newline<-function(x,nmax=35,indent=1) {
   }
 
   #to add whitespace after linebreak
-  if (indent>0) {
-    lbl<-strsplit(w1," ")[[1]]
-    counter<-1
-    while (nchar(lbl[counter])==0) {
-      counter<-counter+1
-    }
-    nws<-counter-1
-    ncm<-nws/2/10 + 0.1*indent
-    wc<-paste(c(w1,w2),collapse=paste0(" \\newline ","\\hspace*{",ncm,"cm}"))
-
+  if (w1=="") {
+	wc<-w2
   } else {
+	  if (indent>0) {
+		lbl<-strsplit(w1," ")[[1]]
+		counter<-1
+		while (nchar(lbl[counter])==0) {
+		  counter<-counter+1
+		}
+		nws<-counter-1
+		ncm<-nws/2/10 + 0.1*indent
+		wc<-paste(c(w1,w2),collapse=paste0(" \\newline ","\\hspace*{",ncm,"cm}"))
 
-    wc<-paste(c(w1,w2),collapse=" \\newline ")
-  }
+	  } else {
 
+		wc<-paste(c(w1,w2),collapse=" \\newline ")
+	  }
+	}
   wc
 }

--- a/tests/testthat/tests-btable.R
+++ b/tests/testthat/tests-btable.R
@@ -1,0 +1,92 @@
+
+dat0 <- data.frame(out_t = c("Total", "t1", "t1"))
+dat1 <- data.frame(c1 = c( "","Var1", "Var2"),c2=c("Group1","10","10"),c3=c("Group2","10","10"))
+dat2 <- data.frame(c1 = c("","","Var1", "Var2"),c2=c("Group1","mean (sd)","10 (3)","10 (3)"),
+	c3=c("Group2","mean (sd)","10 (3)","10 (3)"))
+
+	
+test_that("runs through", {
+	expect_error(r1<-btable(dat0, nhead = 1, nfoot = 0, caption = "Table1",print=FALSE), NA)
+	expect_error(r2<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",print=FALSE), NA)
+	expect_error(r3<-btable(dat2, nhead = 2, nfoot = 0, caption = "Table1",print=FALSE), NA)
+})
+
+test_that("aggregates headers", {
+	r2<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",print=FALSE)
+	r3<-btable(dat2, nhead = 2, nfoot = 0, caption = "Table1",print=FALSE)
+	expect_true(grepl("multicolumn{2}",r3,fixed=TRUE))
+	expect_false(grepl("multicolumn{2}",r2,fixed=TRUE))
+})
+
+test_that("column alignment works", {
+	expect_error(r0<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",
+		aggregate=FALSE,print=FALSE),NA)
+	expect_true(grepl("lcc",r0,fixed=TRUE))	
+	
+	expect_error(r0<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",alignp="2cm",
+		aggregate=FALSE,print=FALSE),NA)
+	expect_true(grepl("{p{2cm}cc",r0,fixed=TRUE))	
+	
+	expect_error(r0<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",print=FALSE),NA)
+	expect_true(grepl("multicolumn{1}{l}{}",r0,fixed=TRUE))
+	
+	expect_error(r0<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",alignh1="c",print=FALSE),NA)
+	expect_true(grepl("multicolumn{1}{c}{}",r0,fixed=TRUE))
+	
+	expect_error(r0<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",aligntot="clc",
+		aggregate=FALSE,print=FALSE),NA)
+	expect_true(grepl("clc",r0,fixed=TRUE))	
+	
+	expect_error(r0<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",aligntot="p{1cm}p{2cm}p{2cm}",
+		aggregate=FALSE,print=FALSE),NA)
+	expect_true(grepl("p{1cm}p{2cm}p{2cm}",r0,fixed=TRUE))
+})
+
+test_that("table environment works", {
+	expect_error(r0<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",print=FALSE),NA)
+	expect_error(r1<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",print=FALSE,rephead=FALSE),NA)
+	
+	expect_error(r2<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",print=FALSE,tab.env="float"),NA)
+	expect_error(r3<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",print=FALSE,tab.env="float",
+		table.placement="H"),NA)
+
+	expect_true(grepl("longtable",r0,fixed=TRUE))
+	expect_true(grepl("continued on next page",r0,fixed=TRUE))
+	
+	expect_true(grepl("longtable",r1,fixed=TRUE))
+	expect_false(grepl("continued on next page",r1,fixed=TRUE))
+	
+	expect_false(grepl("longtable",r2,fixed=TRUE))
+	expect_false(grepl("continued on next page",r2,fixed=TRUE))
+	expect_true(grepl("{table}[ht]",r2,fixed=TRUE))
+	
+	expect_true(grepl("{table}[H]",r3,fixed=TRUE))
+	
+})
+
+test_that("throws error", {
+	expect_error(btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",aligntot="cc",aggregate=FALSE))
+})	
+
+
+test_that("mergerow works", {
+	expect_error(r0<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",mergerow=2,print=FALSE),NA)
+	expect_error(r1<-btable(dat1, nhead = 1, nfoot = 0, caption = "Table1",mergerow=c(2,3),print=FALSE),NA)
+	
+	expect_true(grepl("multicolumn{3}{l}{Var1}",r0,fixed=TRUE))
+	expect_false(grepl("multicolumn{3}{l}{Var2}",r0,fixed=TRUE))
+	expect_true(grepl("multicolumn{3}{l}{Var1}",r1,fixed=TRUE))
+	expect_true(grepl("multicolumn{3}{l}{Var2}",r1,fixed=TRUE))
+})	
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Fix for Arnaud's bug. Should now work with one column tables.
Warning that headers do not respect aligntot if aggregate==TRUE
Account for words in first column longer than nnewline using a warning and splitting directly after the long word.


